### PR TITLE
replace bare except with except Exception in get_from_list

### DIFF
--- a/src/merge.py
+++ b/src/merge.py
@@ -160,7 +160,7 @@ def get_datetime(dt:datetime) -> datetime:
 def get_from_list(items:list, value:str):
     try:
         return_value = items.get(value)
-    except:
+    except Exception:
         return_value = None
 
     return return_value


### PR DESCRIPTION
Bare except catches KeyboardInterrupt and SystemExit, silently swallowing fatal signals. Narrowing to Exception preserves the intended error-suppression behavior without masking process-level signals.