### PR TITLE
add click as an explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "calendar-merge"
 version = "0.1.1"
 requires-python = ">=3.12"
 dependencies = [
+    "click>=8.0",
     "dotenv>=0.9.9",
     "google-generativeai>=0.8.5",
     "icalendar>=6.3.1",


### PR DESCRIPTION
click is imported and used for interactive 2FA prompts but was never declared in pyproject.toml — it only worked as a transitive dependency.