### PR TITLE
fix misleading type hint on get_from_list parameter

### DIFF
--- a/src/merge.py
+++ b/src/merge.py
@@ -153,7 +153,7 @@ def validate_2fa(api: PyiCloudService) -> bool:
 
     return status
 
-def get_from_list(items:list, value:str):
+def get_from_list(items:dict, value:str):
     try:
         return_value = items.get(value)
     except Exception:


### PR DESCRIPTION
Change items parameter hint from list to dict since the function calls .get(), which is a dict method.