### PR TITLE
add unit tests and extract reconciliation logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,11 @@ uv run calendar-merge --first    # Morning sync + AI/Telegram greeting
 uv run calendar-merge --last     # Evening sync + AI/Telegram wrap-up
 ```
 
-No test framework or CI pipeline is currently configured. A `tests/` directory exists but contains no test files.
+Tests use pytest:
+
+```bash
+uv run pytest tests/ -v            # Run all tests
+```
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ dependencies = [
     "pyicloud==2.1.0",
 ]
 
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -20,6 +23,10 @@ include = ["src/merge.py"]
 
 [tool.uv.sources]
 pyfangs = { git = "ssh://git@github.com/leandrorojas/pyfangs", rev = "v0.7.2" }
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
 
 # Optional: CLI entry point (runs merge:main)
 [project.scripts]

--- a/src/merge.py
+++ b/src/merge.py
@@ -122,7 +122,7 @@ def validate_2fa(api: PyiCloudService) -> bool:
 
         devices = api.trusted_devices
         for i, device in enumerate(devices):
-            print_step(TAG_2F_AUTH, f"  {i}: {device.get('deviceName', 'SMS to %s' % device.get('phoneNumber'))}", one_liner=True)
+            print_step(TAG_2F_AUTH, f"  {i}: {device.get('deviceName', f'SMS to {device.get("phoneNumber")}')}", one_liner=True)
 
         device = click.prompt(f"{get_tag(TAG_2F_AUTH)} Which device would you like to use?", default=0)
         device = devices[device]
@@ -144,7 +144,7 @@ def get_datetime(dt:datetime) -> datetime:
 def get_from_list(items, value:str):
     try:
         return_value = items.get(value)
-    except Exception:
+    except (AttributeError, TypeError):
         return_value = None
 
     return return_value

--- a/src/merge.py
+++ b/src/merge.py
@@ -19,7 +19,7 @@ from time import perf_counter
 import google.generativeai as genai
 
 # custom imports
-from pyfangs.yaml import YamlHelper
+from pyfangs.yaml import YamlHelper, YamlError
 from pyfangs.filesystem import FileSystem
 from pyfangs.time import convert_to_utc
 from pyfangs.ai import GeminiAI
@@ -74,7 +74,7 @@ class MergeEvent(object):
     start:datetime
     end:datetime
     full_event:EventObject
-    action:EventAction
+    action:EventAction | None
 
 def validate_2fa(api: PyiCloudService) -> bool:
     status:bool = True
@@ -141,10 +141,10 @@ def validate_2fa(api: PyiCloudService) -> bool:
 def get_datetime(dt:datetime) -> datetime:
     return datetime(dt.year, dt.month, dt.day, dt.hour, dt.minute, tzinfo=dt.tzinfo)
 
-def get_from_list(items:list, value:str):
+def get_from_list(items, value:str):
     try:
         return_value = items.get(value)
-    except:
+    except Exception:
         return_value = None
 
     return return_value
@@ -506,7 +506,7 @@ def main():
         section = YAML_SECTION_SOURCE_CALENDAR.format(index=source_index)
         try:
             calendar_source = yaml_helper.get(section, YAML_SETTING_CALENDAR_SOURCE)
-        except Exception:
+        except YamlError:
             print_step(TAG_CALENDAR_MERGE, term.TerminalColors.yellow.value + "no more source calendars to process" + term.TerminalColors.reset.value, one_liner=True)
             break
 

--- a/src/merge.py
+++ b/src/merge.py
@@ -339,6 +339,43 @@ def _get_ai_tone(yaml_helper:YamlHelper) -> str | None:
     except Exception:
         return None
 
+def _reconcile_events(filtered_icloud_events: list[MergeEvent], source_calendar_events: list[MergeEvent]) -> tuple[list[MergeEvent], bool]:
+    """Match source events against iCloud events by (start, end) and assign actions.
+
+    Returns (merge_events, has_additions).
+    """
+    merge_events: list[MergeEvent] = []
+    has_additions = False
+
+    if filtered_icloud_events:
+        source_event_map: dict[tuple[datetime, datetime], list[MergeEvent]] = {}
+        for source_event in source_calendar_events:
+            source_event_map.setdefault((source_event.start, source_event.end), []).append(source_event)
+
+        for icloud_event in filtered_icloud_events:
+            event_time = (icloud_event.start, icloud_event.end)
+            bucket = source_event_map.get(event_time, [])
+            if bucket:
+                matched = bucket.pop(0)
+                matched.action = EventAction.none
+                icloud_event.action = EventAction.none
+            else:
+                icloud_event.action = EventAction.delete
+            merge_events.append(icloud_event)
+
+        events_to_add = [event for event in source_calendar_events if event.action is None]
+        has_additions = len(events_to_add) > 0
+    else:
+        has_additions = True
+        events_to_add = source_calendar_events
+
+    if has_additions:
+        for source_event in events_to_add:
+            source_event.action = EventAction.add
+            merge_events.append(source_event)
+
+    return merge_events, has_additions
+
 def _collect_icloud_events(raw_events:list, skip_days:list[str]) -> list[MergeEvent]:
     events:list[MergeEvent] = []
     for raw_event in raw_events:
@@ -544,41 +581,15 @@ def main():
         source_tag = f"[{calendar_tag}] {calendar_title}/{calendar_source}"
         print_step(TAG_CALENDAR_MERGE, f"filtering {source_tag} events in iCloud calendar...", False)
         filtered_icloud_events = [event for event in icloud_events if event.title == source_tag]
-        merge_events:list[MergeEvent] = []
-        event_addition = False
         term.print_done()
 
-        print_step(TAG_CALENDAR_MERGE, f"identifying events to remove...", False)
-        if filtered_icloud_events:
-            source_event_map:dict[tuple[datetime, datetime], list[MergeEvent]] = {}
-            for source_event in source_calendar_events:
-                source_event_map.setdefault((source_event.start, source_event.end), []).append(source_event)
-
-            for icloud_event in filtered_icloud_events:
-                event_time = (icloud_event.start, icloud_event.end)
-                bucket = source_event_map.get(event_time, [])
-                if bucket:
-                    matched = bucket.pop(0)
-                    matched.action = EventAction.none
-                    icloud_event.action = EventAction.none
-                else:
-                    icloud_event.action = EventAction.delete
-                merge_events.append(icloud_event)
-
-            events_to_add = [event for event in source_calendar_events if event.action is None]
-            event_addition = len(events_to_add) > 0
-        else:
-            event_addition = True
-            events_to_add = source_calendar_events
-        term.print_done()
-
+        print_step(TAG_CALENDAR_MERGE, f"reconciling events...", False)
+        merge_events, event_addition = _reconcile_events(filtered_icloud_events, source_calendar_events)
         if event_addition:
-            print_step(TAG_CALENDAR_MERGE, f"identifying events to add...", False)
-            for source_event in events_to_add:
-                source_event.title = source_tag
-                source_event.action = EventAction.add
-                merge_events.append(source_event)
-            term.print_done()
+            for event in merge_events:
+                if event.action == EventAction.add:
+                    event.title = source_tag
+        term.print_done()
 
         print_step(TAG_CALENDAR_MERGE, f"synchronizing events to iCloud calendar...", False)
         actionable_events = [event for event in merge_events if event.action != EventAction.none]

--- a/src/merge.py
+++ b/src/merge.py
@@ -70,10 +70,10 @@ class EventAction(Enum):
 
 @dataclass
 class MergeEvent(object):
-    title:str
+    title:str | None
     start:datetime
     end:datetime
-    full_event:EventObject
+    full_event:EventObject | None
     action:EventAction | None
 
 def validate_2fa(api: PyiCloudService) -> bool:

--- a/src/merge.py
+++ b/src/merge.py
@@ -366,7 +366,7 @@ def _reconcile_events(filtered_icloud_events: list[MergeEvent], source_calendar_
         events_to_add = [event for event in source_calendar_events if event.action is None]
         has_additions = len(events_to_add) > 0
     else:
-        has_additions = True
+        has_additions = len(source_calendar_events) > 0
         events_to_add = source_calendar_events
 
     if has_additions:
@@ -583,7 +583,7 @@ def main():
         filtered_icloud_events = [event for event in icloud_events if event.title == source_tag]
         term.print_done()
 
-        print_step(TAG_CALENDAR_MERGE, f"reconciling events...", False)
+        print_step(TAG_CALENDAR_MERGE, "reconciling events...", False)
         merge_events, event_addition = _reconcile_events(filtered_icloud_events, source_calendar_events)
         if event_addition:
             for event in merge_events:
@@ -591,7 +591,7 @@ def main():
                     event.title = source_tag
         term.print_done()
 
-        print_step(TAG_CALENDAR_MERGE, f"synchronizing events to iCloud calendar...", False)
+        print_step(TAG_CALENDAR_MERGE, "synchronizing events to iCloud calendar...", False)
         actionable_events = [event for event in merge_events if event.action != EventAction.none]
         for merge_event in actionable_events:
             if merge_event.action == EventAction.add:

--- a/src/merge.py
+++ b/src/merge.py
@@ -83,57 +83,57 @@ def validate_2fa(api: PyiCloudService) -> bool:
         security_key_names = api.security_key_names
 
         if security_key_names:
-            print_step(TAG_2F_AUTH, f"Security key confirmation is required. Please plug in one of the following keys: {', '.join(security_key_names)}", True)
+            print_step(TAG_2F_AUTH, f"Security key confirmation is required. Please plug in one of the following keys: {', '.join(security_key_names)}", one_liner=True)
 
             devices = api.fido2_devices
 
-            print_step(TAG_2F_AUTH, "Available FIDO2 devices:", True)
+            print_step(TAG_2F_AUTH, "Available FIDO2 devices:", one_liner=True)
 
             for idx, dev in enumerate(devices, start=1):
-                print_step(TAG_2F_AUTH, f"{idx}: {dev}", True)
+                print_step(TAG_2F_AUTH, f"{idx}: {dev}", one_liner=True)
 
             choice = click.prompt(f"{get_tag(TAG_2F_AUTH)} Select a FIDO2 device by number", type=click.IntRange(1, len(devices)), default=1,)
             selected_device = devices[choice - 1]
 
-            print_step(TAG_2F_AUTH, "Please confirm the action using the security key", True)
+            print_step(TAG_2F_AUTH, "Please confirm the action using the security key", one_liner=True)
 
             api.confirm_security_key(selected_device)
 
         else:
-            print_step(TAG_2F_AUTH, "Two-factor authentication required.", True)
-            print_step(TAG_2F_AUTH, "requesting Apple 2FA code via Telegram...", True)
+            print_step(TAG_2F_AUTH, "Two-factor authentication required.", one_liner=True)
+            print_step(TAG_2F_AUTH, "requesting Apple 2FA code via Telegram...", one_liner=True)
             result = api.validate_2fa_code(prompt_telegram_reply("provide the Apple 2FA code"))
-            print_step(TAG_2F_AUTH, f"Code validation result: {result}", True)
+            print_step(TAG_2F_AUTH, f"Code validation result: {result}", one_liner=True)
 
             if not result:
-                print_step(TAG_2F_AUTH, "Failed to verify security code", True)
+                print_step(TAG_2F_AUTH, "Failed to verify security code", one_liner=True)
                 status = False
 
         if not api.is_trusted_session:
-            print_step(TAG_2F_AUTH, "Session is not trusted. Requesting trust...", True)
+            print_step(TAG_2F_AUTH, "Session is not trusted. Requesting trust...", one_liner=True)
             result = api.trust_session()
-            print_step(TAG_2F_AUTH, f"Session trust result {result}", True)
+            print_step(TAG_2F_AUTH, f"Session trust result {result}", one_liner=True)
 
             if not result:
-                print_step(TAG_2F_AUTH, "Failed to request trust. You will likely be prompted for confirmation again in the coming weeks", True)
+                print_step(TAG_2F_AUTH, "Failed to request trust. You will likely be prompted for confirmation again in the coming weeks", one_liner=True)
 
     elif api.requires_2sa:
-        print_step(TAG_2F_AUTH, "Two-step authentication required. Your trusted devices are:", True)
+        print_step(TAG_2F_AUTH, "Two-step authentication required. Your trusted devices are:", one_liner=True)
 
         devices = api.trusted_devices
         for i, device in enumerate(devices):
-            print_step(TAG_2F_AUTH, f"  {i}: {device.get('deviceName', 'SMS to %s' % device.get('phoneNumber'))}", True)
+            print_step(TAG_2F_AUTH, f"  {i}: {device.get('deviceName', 'SMS to %s' % device.get('phoneNumber'))}", one_liner=True)
 
         device = click.prompt(f"{get_tag(TAG_2F_AUTH)} Which device would you like to use?", default=0)
         device = devices[device]
         if not api.send_verification_code(device):
-            print_step(TAG_2F_AUTH, "Failed to send verification code", True)
+            print_step(TAG_2F_AUTH, "Failed to send verification code", one_liner=True)
             status = False
 
         send_telegram_message("Calendar merger triggered Apple two-step authentication. Please enter the validation code.")
         code = click.prompt(f"{get_tag(TAG_2F_AUTH)} Please enter validation code")
         if not api.validate_verification_code(device, code):
-            print_step(TAG_2F_AUTH, "Failed to verify verification code", True)
+            print_step(TAG_2F_AUTH, "Failed to verify verification code", one_liner=True)
             status = False
 
     return status
@@ -409,7 +409,7 @@ def main():
     args = parser.parse_args()
 
     #region CONFIG_LOAD
-    print_step(TAG_CALENDAR_MERGE, "reading config...", False)
+    print_step(TAG_CALENDAR_MERGE, "reading config...", one_liner=False)
     load_dotenv()
     fs = FileSystem()
     config_path = fs.join_paths(str(Path(__file__).resolve().parent.parent), YAML_FILENAME)
@@ -447,7 +447,7 @@ def main():
     #endregion
 
     #region ICLOUD_AUTH
-    print_step(TAG_ICLOUD_AUTH, "authenticating with iCloud...", False)
+    print_step(TAG_ICLOUD_AUTH, "authenticating with iCloud...", one_liner=False)
     try:
         icloud_service = PyiCloudService(os.getenv(ENV_ICLOUD_USER), os.getenv(ENV_ICLOUD_PASS))
     except Exception as err:
@@ -468,7 +468,7 @@ def main():
     #endregion
 
     #region ICLOUD_CALENDAR_LOAD
-    print_step(TAG_CALENDAR_MERGE, "loading iCloud calendar events...", False)
+    print_step(TAG_CALENDAR_MERGE, "loading iCloud calendar events...", one_liner=False)
     calendar_service = icloud_service.calendar
     try:
         calendars = calendar_service.get_calendars()
@@ -501,16 +501,16 @@ def main():
     term.print_done()
     #endregion
 
-    print_step(TAG_CALENDAR_MERGE, term.TerminalColors.yellow.value + "processing source calendars" + term.TerminalColors.reset.value, True)
+    print_step(TAG_CALENDAR_MERGE, term.TerminalColors.yellow.value + "processing source calendars" + term.TerminalColors.reset.value, one_liner=True)
     while True:
         section = YAML_SECTION_SOURCE_CALENDAR.format(index=source_index)
         try:
             calendar_source = yaml_helper.get(section, YAML_SETTING_CALENDAR_SOURCE)
         except Exception:
-            print_step(TAG_CALENDAR_MERGE, term.TerminalColors.yellow.value + "no more source calendars to process" + term.TerminalColors.reset.value, True)
+            print_step(TAG_CALENDAR_MERGE, term.TerminalColors.yellow.value + "no more source calendars to process" + term.TerminalColors.reset.value, one_liner=True)
             break
 
-        print_step(TAG_CALENDAR_MERGE, f"reading {calendar_source} [{source_index}] source calendar config...", False)
+        print_step(TAG_CALENDAR_MERGE, f"reading {calendar_source} [{source_index}] source calendar config...", one_liner=False)
         try:
             calendar_tag = yaml_helper.get(section, YAML_SETTING_CALENDAR_TAG)
             calendar_title = yaml_helper.get(section, YAML_SETTING_CALENDAR_TITLE)
@@ -525,7 +525,7 @@ def main():
             raise RuntimeError(f"Missing calendar URL for index {source_index}")
         term.print_done()
 
-        print_step(TAG_CALENDAR_MERGE, f"downloading calendar {calendar_source} [{source_index}]...", False)
+        print_step(TAG_CALENDAR_MERGE, f"downloading calendar {calendar_source} [{source_index}]...", one_liner=False)
         timestamp_filename = fs.join_paths(fs.get_temp_dir(), f"{convert_to_utc(now).strftime('%Y%m%d%H%M%S%f')}.ics")
         try:
             fs.download(calendar_url, timestamp_filename)
@@ -534,7 +534,7 @@ def main():
             raise RuntimeError(f"Unable to download calendar {calendar_source} [{source_index}]") from err
         term.print_done()
 
-        print_step(TAG_CALENDAR_MERGE, f"reading source calendar from {timestamp_filename}...", False)
+        print_step(TAG_CALENDAR_MERGE, f"reading source calendar from {timestamp_filename}...", one_liner=False)
         try:
             with open(timestamp_filename, "rb") as ics_file:
                 ics_calendar = Calendar.from_ical(ics_file.read())
@@ -547,7 +547,7 @@ def main():
         utc_cut_off_date = convert_to_utc(cut_off_date)
         term.print_done()
 
-        print_step(TAG_CALENDAR_MERGE, f"filtering events from source calendar {calendar_source} [{source_index}]...", False)
+        print_step(TAG_CALENDAR_MERGE, f"filtering events from source calendar {calendar_source} [{source_index}]...", one_liner=False)
         for file_event in ics_calendar.walk(ICS_TAG_VEVENT):
             ooo_status = get_from_list(file_event, ICS_FIELD_OOO)
             if ooo_status is not None:
@@ -579,11 +579,11 @@ def main():
         term.print_done()
         
         source_tag = f"[{calendar_tag}] {calendar_title}/{calendar_source}"
-        print_step(TAG_CALENDAR_MERGE, f"filtering {source_tag} events in iCloud calendar...", False)
+        print_step(TAG_CALENDAR_MERGE, f"filtering {source_tag} events in iCloud calendar...", one_liner=False)
         filtered_icloud_events = [event for event in icloud_events if event.title == source_tag]
         term.print_done()
 
-        print_step(TAG_CALENDAR_MERGE, "reconciling events...", False)
+        print_step(TAG_CALENDAR_MERGE, "reconciling events...", one_liner=False)
         merge_events, event_addition = _reconcile_events(filtered_icloud_events, source_calendar_events)
         if event_addition:
             for event in merge_events:
@@ -591,7 +591,7 @@ def main():
                     event.title = source_tag
         term.print_done()
 
-        print_step(TAG_CALENDAR_MERGE, "synchronizing events to iCloud calendar...", False)
+        print_step(TAG_CALENDAR_MERGE, "synchronizing events to iCloud calendar...", one_liner=False)
         actionable_events = [event for event in merge_events if event.action != EventAction.none]
         for merge_event in actionable_events:
             if merge_event.action == EventAction.add:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,324 @@
+import pytest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from merge import (
+    EventAction,
+    MergeEvent,
+    get_datetime,
+    get_from_list,
+    build_datetime,
+    get_tag,
+    _normalize_skip_days,
+    _calculate_future_date,
+    _end_of_day,
+    _reconcile_events,
+)
+
+
+# --- EventAction enum ---
+
+class TestEventAction:
+    def test_values(self):
+        assert EventAction.none.value == 0
+        assert EventAction.add.value == 1
+        assert EventAction.delete.value == 2
+
+
+# --- MergeEvent dataclass ---
+
+class TestMergeEvent:
+    def test_construction(self):
+        dt = datetime(2026, 3, 27, 10, 0)
+        event = MergeEvent(title="test", start=dt, end=dt, full_event=None, action=EventAction.add)
+        assert event.title == "test"
+        assert event.start == dt
+        assert event.action == EventAction.add
+
+    def test_action_mutable(self):
+        dt = datetime(2026, 3, 27, 10, 0)
+        event = MergeEvent(title="test", start=dt, end=dt, full_event=None, action=None)
+        event.action = EventAction.delete
+        assert event.action == EventAction.delete
+
+    def test_none_fields(self):
+        dt = datetime(2026, 3, 27, 10, 0)
+        event = MergeEvent(title=None, start=dt, end=dt, full_event=None, action=None)
+        assert event.title is None
+        assert event.full_event is None
+        assert event.action is None
+
+
+# --- get_datetime ---
+
+class TestGetDatetime:
+    def test_strips_seconds_and_microseconds(self):
+        dt = datetime(2026, 3, 27, 14, 30, 45, 123456)
+        result = get_datetime(dt)
+        assert result == datetime(2026, 3, 27, 14, 30)
+        assert result.second == 0
+        assert result.microsecond == 0
+
+    def test_preserves_timezone(self):
+        tz = ZoneInfo("America/New_York")
+        dt = datetime(2026, 3, 27, 14, 30, 45, tzinfo=tz)
+        result = get_datetime(dt)
+        assert result.tzinfo == tz
+
+    def test_naive_datetime(self):
+        dt = datetime(2026, 3, 27, 14, 30, 45)
+        result = get_datetime(dt)
+        assert result.tzinfo is None
+
+    def test_midnight_boundary(self):
+        dt = datetime(2026, 1, 1, 0, 0, 59)
+        result = get_datetime(dt)
+        assert result == datetime(2026, 1, 1, 0, 0)
+
+
+# --- get_from_list ---
+
+class TestGetFromList:
+    def test_dict_get(self):
+        assert get_from_list({"a": 1}, "a") == 1
+
+    def test_missing_key(self):
+        assert get_from_list({"a": 1}, "b") is None
+
+    def test_non_dict_input(self):
+        assert get_from_list([1, 2], "x") is None
+
+    def test_none_input(self):
+        assert get_from_list(None, "x") is None
+
+    def test_value_is_none(self):
+        assert get_from_list({"a": None}, "a") is None
+
+
+# --- build_datetime ---
+
+class TestBuildDatetime:
+    def test_basic(self):
+        tz = ZoneInfo("UTC")
+        result = build_datetime([0, 2026, 3, 27, 14, 30], tz)
+        assert result == datetime(2026, 3, 27, 14, 30, tzinfo=tz)
+
+    def test_non_utc_timezone(self):
+        tz = ZoneInfo("America/New_York")
+        result = build_datetime([0, 2026, 3, 27, 14, 30], tz)
+        assert result.tzinfo == tz
+
+    def test_tuple_input(self):
+        tz = ZoneInfo("UTC")
+        result = build_datetime((0, 2026, 3, 27, 14, 30), tz)
+        assert result == datetime(2026, 3, 27, 14, 30, tzinfo=tz)
+
+    def test_midnight(self):
+        tz = ZoneInfo("UTC")
+        result = build_datetime([0, 2026, 1, 1, 0, 0], tz)
+        assert result == datetime(2026, 1, 1, 0, 0, tzinfo=tz)
+
+    def test_short_sequence_raises(self):
+        with pytest.raises(IndexError):
+            build_datetime([0, 2026, 3], ZoneInfo("UTC"))
+
+
+# --- get_tag ---
+
+class TestGetTag:
+    def test_basic(self):
+        assert get_tag("foo") == "[foo]"
+
+    def test_empty_string(self):
+        assert get_tag("") == "[]"
+
+    def test_nested_brackets(self):
+        assert get_tag("[nested]") == "[[nested]]"
+
+
+# --- _normalize_skip_days ---
+
+class TestNormalizeSkipDays:
+    def test_string_input(self):
+        assert _normalize_skip_days("5, 6") == ["5", "6"]
+
+    def test_string_extra_whitespace(self):
+        assert _normalize_skip_days(" 5 , 6 , ") == ["5", "6"]
+
+    def test_list_of_ints(self):
+        assert _normalize_skip_days([5, 6]) == ["5", "6"]
+
+    def test_list_of_strings(self):
+        assert _normalize_skip_days(["5", "6"]) == ["5", "6"]
+
+    def test_empty_string(self):
+        assert _normalize_skip_days("") == []
+
+    def test_none(self):
+        assert _normalize_skip_days(None) == []
+
+    def test_empty_list(self):
+        assert _normalize_skip_days([]) == []
+
+    def test_single_value(self):
+        assert _normalize_skip_days("0") == ["0"]
+
+
+# --- _calculate_future_date ---
+
+class TestCalculateFutureDate:
+    def test_no_skip_days(self):
+        # Monday 2026-03-23 + 5 days = Saturday 2026-03-28
+        start = datetime(2026, 3, 23)
+        result = _calculate_future_date(start, 5, [])
+        assert result == datetime(2026, 3, 28)
+
+    def test_skip_weekends_from_monday(self):
+        # Monday 2026-03-23, counting from next day: Tue(1), Wed(2), Thu(3), Fri(4), Sat(skip), Sun(skip), Mon(5)
+        start = datetime(2026, 3, 23)
+        result = _calculate_future_date(start, 5, ["5", "6"])
+        assert result == datetime(2026, 3, 30)
+        assert result.weekday() == 0  # Monday
+
+    def test_skip_weekends_spanning_weekend(self):
+        # Thursday 2026-03-26 + 3 non-weekend days with skip [5, 6]
+        # Fri(1), Sat(skip), Sun(skip), Mon(2), Tue(3) = Tuesday 2026-03-31
+        start = datetime(2026, 3, 26)
+        result = _calculate_future_date(start, 3, ["5", "6"])
+        assert result == datetime(2026, 3, 31)
+        assert result.weekday() == 1  # Tuesday
+
+    def test_zero_future_days(self):
+        start = datetime(2026, 3, 23)
+        result = _calculate_future_date(start, 0, ["5", "6"])
+        assert result == start
+
+    def test_future_days_one(self):
+        # Monday + 1 = Tuesday
+        start = datetime(2026, 3, 23)
+        result = _calculate_future_date(start, 1, [])
+        assert result == datetime(2026, 3, 24)
+
+    def test_only_one_day_allowed(self):
+        # Skip everything except Sunday (6). Start Monday 2026-03-23.
+        # skip 0,1,2,3,4,5 = Mon-Sat. Only Sunday counts.
+        # Next Sunday = 2026-03-29 (count 1), then 2026-04-05 (count 2)
+        start = datetime(2026, 3, 23)
+        result = _calculate_future_date(start, 2, ["0", "1", "2", "3", "4", "5"])
+        assert result == datetime(2026, 4, 5)
+        assert result.weekday() == 6  # Sunday
+
+
+# --- _end_of_day ---
+
+class TestEndOfDay:
+    def test_basic(self):
+        tz = ZoneInfo("UTC")
+        dt = datetime(2026, 3, 27, 10, 30, tzinfo=tz)
+        result = _end_of_day(dt)
+        assert result == datetime(2026, 3, 27, 23, 59, 59, tzinfo=tz)
+
+    def test_already_end_of_day(self):
+        dt = datetime(2026, 3, 27, 23, 59, 59)
+        result = _end_of_day(dt)
+        assert result == dt
+
+    def test_midnight_input(self):
+        dt = datetime(2026, 3, 27, 0, 0, 0)
+        result = _end_of_day(dt)
+        assert result == datetime(2026, 3, 27, 23, 59, 59)
+
+    def test_preserves_naive(self):
+        dt = datetime(2026, 3, 27, 10, 30)
+        result = _end_of_day(dt)
+        assert result.tzinfo is None
+
+
+# --- _reconcile_events ---
+
+def _make_event(start_hour, end_hour, title="test", action=None, full_event=None):
+    """Helper to create MergeEvent instances for testing."""
+    start = datetime(2026, 3, 27, start_hour, 0, tzinfo=ZoneInfo("UTC"))
+    end = datetime(2026, 3, 27, end_hour, 0, tzinfo=ZoneInfo("UTC"))
+    return MergeEvent(title=title, start=start, end=end, full_event=full_event, action=action)
+
+
+class TestReconcileEvents:
+    def test_no_icloud_all_source_added(self):
+        source = [_make_event(9, 10), _make_event(11, 12)]
+        merge_events, has_additions = _reconcile_events([], source)
+        assert has_additions is True
+        assert len(merge_events) == 2
+        assert all(e.action == EventAction.add for e in merge_events)
+
+    def test_matching_events_marked_none(self):
+        icloud = [_make_event(9, 10, title="[WRK] Work/Google")]
+        source = [_make_event(9, 10)]
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        assert has_additions is False
+        assert len(merge_events) == 1
+        assert merge_events[0].action == EventAction.none
+
+    def test_icloud_not_in_source_deleted(self):
+        icloud = [_make_event(9, 10, title="[WRK] Work/Google")]
+        source = []
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        assert has_additions is False
+        assert len(merge_events) == 1
+        assert merge_events[0].action == EventAction.delete
+
+    def test_source_not_in_icloud_added(self):
+        icloud = [_make_event(9, 10, title="[WRK] Work/Google")]
+        source = [_make_event(9, 10), _make_event(14, 15)]
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        assert has_additions is True
+        added = [e for e in merge_events if e.action == EventAction.add]
+        matched = [e for e in merge_events if e.action == EventAction.none]
+        assert len(added) == 1
+        assert added[0].start.hour == 14
+        assert len(matched) == 1
+
+    def test_both_empty(self):
+        merge_events, has_additions = _reconcile_events([], [])
+        assert has_additions is True
+        assert len(merge_events) == 0
+
+    def test_duplicate_times_in_source(self):
+        icloud = [_make_event(9, 10, title="[WRK] Work/Google")]
+        source = [_make_event(9, 10), _make_event(9, 10)]
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        # One matches icloud, one is new
+        assert has_additions is True
+        added = [e for e in merge_events if e.action == EventAction.add]
+        matched = [e for e in merge_events if e.action == EventAction.none]
+        assert len(added) == 1
+        assert len(matched) == 1
+
+    def test_duplicate_times_in_icloud(self):
+        icloud = [_make_event(9, 10, title="[WRK] Work/Google"), _make_event(9, 10, title="[WRK] Work/Google")]
+        source = [_make_event(9, 10)]
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        # One icloud matches, other is deleted
+        assert has_additions is False
+        deleted = [e for e in merge_events if e.action == EventAction.delete]
+        matched = [e for e in merge_events if e.action == EventAction.none]
+        assert len(deleted) == 1
+        assert len(matched) == 1
+
+    def test_mixed_add_delete_none(self):
+        icloud = [
+            _make_event(9, 10, title="[WRK] Work/Google"),   # matches source
+            _make_event(11, 12, title="[WRK] Work/Google"),   # no source match → delete
+        ]
+        source = [
+            _make_event(9, 10),   # matches icloud
+            _make_event(14, 15),  # no icloud match → add
+        ]
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        assert has_additions is True
+        actions = {e.action: [] for e in merge_events}
+        for e in merge_events:
+            actions[e.action].append(e)
+        assert len(actions[EventAction.none]) == 1
+        assert len(actions[EventAction.delete]) == 1
+        assert len(actions[EventAction.add]) == 1

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -236,7 +236,7 @@ class TestEndOfDay:
 
 # --- _reconcile_events ---
 
-def _make_event(start_hour, end_hour, title="test", action=None, full_event=None):
+def _make_event(start_hour, end_hour, title="test", action=None, full_event=None) -> MergeEvent:
     """Helper to create MergeEvent instances for testing."""
     start = datetime(2026, 3, 27, start_hour, 0, tzinfo=ZoneInfo("UTC"))
     end = datetime(2026, 3, 27, end_hour, 0, tzinfo=ZoneInfo("UTC"))
@@ -280,7 +280,7 @@ class TestReconcileEvents:
 
     def test_both_empty(self):
         merge_events, has_additions = _reconcile_events([], [])
-        assert has_additions is True
+        assert has_additions is False
         assert len(merge_events) == 0
 
     def test_duplicate_times_in_source(self):

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,11 @@ dependencies = [
     { name = "pyicloud" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
@@ -58,7 +63,9 @@ requires-dist = [
     { name = "icalendar", specifier = ">=6.3.1" },
     { name = "pyfangs", git = "ssh://git@github.com/leandrorojas/pyfangs?rev=v0.7.2" },
     { name = "pyicloud", specifier = "==2.1.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "certifi"


### PR DESCRIPTION
- Extract _reconcile_events() from main() for testability
- Add pytest as dev dependency with pyproject.toml config
- Add 47 unit tests covering all pure logic functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented pytest as the test runner and added a command snippet to run the test suite.

* **Tests**
  * Added a comprehensive pytest suite covering event validation, date/time utilities, data normalization, and reconciliation scenarios.

* **Refactor**
  * Reworked event reconciliation logic and adjusted console output formatting for merge and authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->