### PR TITLE
docs: align CLAUDE.md and README with v0.1.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,20 +7,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 uv sync                          # Install dependencies
 uv run calendar-merge            # Run calendar merge
-uv run calendar-merge --first    # Morning sync + AI/Telegram greeting
-uv run calendar-merge --last     # Evening sync + AI/Telegram wrap-up
+uv run calendar-merge --first    # Morning sync + Telegram start-of-day notification
+uv run calendar-merge --last     # Evening sync + Telegram end-of-day notification
 ```
 
 No test framework or CI pipeline is currently configured.
 
 ## Architecture
 
-Single-file Python application (`src/merge.py`) that merges multiple ICS calendar feeds into one iCloud calendar. The codebase was rolled back to v0.1.3 in March 2026.
+Single-file Python application (`src/merge.py`) that merges multiple ICS calendar feeds into one iCloud calendar.
 
 **Main flow (sequential regions in `main()`):**
 
-1. **CONFIG_LOAD** — reads `.env` + `config.yaml` (skip_days, future_events_days, ai_tone); initializes Gemini AI client if `--first`/`--last`
-2. **ICLOUD_AUTH** — authenticates via PyiCloudService; handles 2FA (FIDO2 or code via Telegram poll)
+1. **CONFIG_LOAD** — reads `.env` + `config.yaml` (skip_days, future_events_days)
+2. **ICLOUD_AUTH** — authenticates via PyiCloudService; handles 2FA (FIDO2 security key, or trusted-device code via Telegram poll)
 3. **ICLOUD_CALENDAR_LOAD** — fetches iCloud calendar GUID, computes date range (today → future non-skipped days), loads existing iCloud events
 4. **Source calendar loop** — for each `source-calendar-N`: downloads ICS, parses VEVENTs, filters by date range and skip_days, reconciles against iCloud events by `(start, end)` tuple, then applies add/delete actions via iCloud API
 
@@ -28,13 +28,14 @@ Single-file Python application (`src/merge.py`) that merges multiple ICS calenda
 
 **Date filtering:** `_calculate_future_date()` counts N non-skipped weekdays forward — so `future_events_days: 5` with weekends skipped may span 7+ calendar days.
 
+**2FA flow (pyicloud 2.5.0):** `api.request_2fa_code()` triggers the trusted-device push. The SMS fallback is explicitly disabled via `api._can_request_sms_2fa_code = lambda: False` because pyicloud's trusted-device bridge can time out waiting for the WebSocket return payload (while still successfully pushing the code to the device), which would otherwise switch the delivery method to `"sms"` and reject the trusted-device code at validation.
+
 ## Dependencies
 
-- `pyfangs` — private library (`ssh://git@github.com/leandrorojas/pyfangs`): provides YamlHelper, FileSystem, terminal colors, Telegram (TelegramNotifier), AI (GeminiAI), and UTC conversion
-- `pyicloud` — iCloud API (calendar service, 2FA)
+- `pyfangs` (v0.7.3+) — private library (`ssh://git@github.com/leandrorojas/pyfangs`): provides YamlHelper, FileSystem, terminal colors, Telegram (TelegramNotifier), and UTC conversion. The AI (GeminiAI) and DB (Postgres) modules are available as optional extras but not used here.
+- `pyicloud` (2.5.0) — iCloud API (calendar service, HSA2 2FA via trusted-device bridge)
 - `icalendar` — ICS file parsing
-- `google-generativeai` — Gemini AI for Telegram message generation
-- `click` — used for interactive 2FA prompts (note: not declared in pyproject.toml)
+- `click` — used for interactive 2FA prompts (note: not declared in pyproject.toml, comes via pyicloud)
 
 ## Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Single-file Python application (`src/merge.py`) that merges multiple ICS calenda
 
 ## Dependencies
 
-- `pyfangs` (v0.7.3+) — private library (`ssh://git@github.com/leandrorojas/pyfangs`): provides YamlHelper, FileSystem, terminal colors, Telegram (TelegramNotifier), and UTC conversion. The AI (GeminiAI) and DB (Postgres) modules are available as optional extras but not used here.
+- `pyfangs` (v0.7.3) — private library (`ssh://git@github.com/leandrorojas/pyfangs`): provides YamlHelper, FileSystem, terminal colors, Telegram (TelegramNotifier), and UTC conversion. The AI (GeminiAI) and DB (Postgres) modules are available as optional extras but not used here.
 - `pyicloud` (2.5.0) — iCloud API (calendar service, HSA2 2FA via trusted-device bridge)
 - `icalendar` — ICS file parsing
 - `click` — used for interactive 2FA prompts (note: not declared in pyproject.toml, comes via pyicloud)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Merge multiple ICS calendars (Google, Outlook, iCloud, etc.) into a single, unif
 - Pulls events from any calendar that can expose an ICS feed.
 - Normalizes timezones and filters out weekends (or any days you choose).
 - Tags each imported event so you can trace the original source.
-- Works with iCloud's built-in 2FA flow.
-- Optional Telegram alerts (including morning/night summaries via Gemini AI) keep you informed even when you're away from the terminal.
+- Works with iCloud's built-in 2FA flow (trusted-device push via Telegram).
+- Optional Telegram alerts for start-of-day and end-of-day notifications.
 
 ## Requirements
 - Python 3.12+
@@ -44,9 +44,8 @@ Add one entry per calendar feed.
 
 - `ICLOUD_USERNAME` and `ICLOUD_PASSWORD`: iCloud credentials the script will use to connect.
 - `CALENDAR_URL_N`: ICS feed URLs where `N` starts at `0` and increments (`CALENDAR_URL_0`, `CALENDAR_URL_1`, ...). Each URL must have a matching `source-calendar-N` section in `config.yaml`.
-- `TELEGRAM_BOT_API_TOKEN`: Bot token used for notifications (optional, required if you want Telegram alerts).
+- `TELEGRAM_BOT_API_TOKEN`: Bot token used for notifications and 2FA code entry (optional, required if you want Telegram alerts or 2FA handling).
 - `TELEGRAM_CHAT_ID`: Destination chat/channel id. Required whenever `TELEGRAM_BOT_API_TOKEN` is set. To obtain it, send any message to your bot, then call `https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates` and look for `"chat":{"id": ...}` in the response.
-- `GEMINI_API_KEY`: API key for the Gemini AI helper. Required only when using the Telegram morning/night summaries described below.
 
 ### `config.yaml`
 
@@ -54,7 +53,6 @@ Control which days are synced and how each calendar is labeled.
 
 - `config.skip_days`: Comma-separated numbers where `0=Monday` and `6=Sunday`. Events that start on these days are ignored (e.g., `5, 6` skips Saturday and Sunday).
 - `config.future_events_days`: Number of non-skipped days ahead to include. `_calculate_future_date()` walks forward from the current date, counting only days not in `skip_days`, so the actual calendar span depends on which day the script runs. For example, with `skip_days: 5, 6` and `future_events_days: 5`: starting on a Monday the window is 5 calendar days (Mon→Fri), but starting on a Wednesday it spans 7 calendar days (Wed→next Tue, skipping Sat and Sun).
-- `config.ai_tone`: Optional text describing how Gemini AI should shape its responses (e.g., `"friendly"`, `"concise/professional"`). Use an empty string to leave Gemini’s default tone.
 - `source-calendar-N`: Duplicate this block per calendar and keep `N` in sync with the `.env` file.
   - `source`: Short name for the upstream calendar (e.g., `Google`, `Outlook`).
   - `tag`: Label enclosed in brackets in the generated iCloud event title.
@@ -66,7 +64,6 @@ Example:
 config:
   skip_days: 5, 6
   future_events_days: 7
-  ai_tone: "friendly and concise"
 
 source-calendar-0:
   source: "Work"
@@ -92,24 +89,24 @@ uv run calendar-merge
 Add the optional flags when you want Telegram updates:
 
 ```bash
-# Morning sync + AI/Telegram "good morning"
+# Morning sync + Telegram start-of-day message
 uv run calendar-merge --first
 
-# Evening sync + AI/Telegram wrap-up
+# Evening sync + Telegram end-of-day message
 uv run calendar-merge --last
 ```
 
-During the first execution you may be prompted for iCloud two-factor authentication. Subsequent runs reuse the trusted session when possible.
+During the first execution you will be prompted for iCloud two-factor authentication: a 6-digit code is pushed to your trusted Apple devices, and the script sends a Telegram message asking you to reply with the code. Subsequent runs reuse the trusted session when possible.
 
 ### Scheduling
 
 To keep your calendars in sync automatically, hook the command into your scheduler of choice (e.g., `cron`, launchd, Windows Task Scheduler). Make sure the job runs under a user session that has the required iCloud authentication.
 
-#### Telegram / AI summaries
+#### Telegram notifications
 
-- Add `--first` to send a “day is starting” Telegram notification (optionally AI-generated via Gemini).
-- Add `--last` to send an “end of day” notification.
-- Both flags can be combined when you run the script twice per day (morning/evening). The notifications gracefully fall back to static messages if Gemini or Telegram are not configured.
+- Add `--first` to send a "day is starting" Telegram notification.
+- Add `--last` to send an "end of day" Telegram notification.
+- Both flags can be combined when you run the script twice per day (morning/evening).
 - To validate your Telegram setup, send a test message to the bot and confirm the script can deliver notifications to the configured `TELEGRAM_CHAT_ID`.
 
 ## Notes


### PR DESCRIPTION
## Summary
- Remove all references to Gemini AI, ai_tone, and GEMINI_API_KEY
- Update pyicloud notes to reflect 2.5.0 and trusted-device bridge flow
- Document the SMS fallback disable and why it's needed
- Update --first/--last descriptions (plain Telegram messages, no AI)
- Note pyfangs v0.7.3 with optional AI/DB extras

## Test plan
- [x] No code changes — docs only
- [x] Manually reviewed for accuracy against v0.1.4 code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Telegram-based start/end-of-day notification and 2FA flow descriptions; removed AI/Gemini morning/wrap-up wording
  * Removed Gemini API from configuration requirements and related config settings
  * Clarified how Telegram credentials are used for alerts and 2FA

* **Chores**
  * Noted dependency adjustments: pyfangs pinned to v0.7.3 and pyicloud bumped to 2.5.0; clarified dependency sourcing and compatibility notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->