### PR TITLE
tests: unit tests and _reconcile_events refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pre-commit>=4.0",
+    "pytest>=8.0",
     "ruff>=0.9",
 ]
 
@@ -43,6 +44,10 @@ ignore = [
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
 
 # 🔑 Tell Hatch to include your single module
 [tool.hatch.build.targets.wheel]

--- a/src/merge.py
+++ b/src/merge.py
@@ -348,6 +348,47 @@ def _end_of_day(dt: datetime) -> datetime:
     return datetime(dt.year, dt.month, dt.day, 23, 59, 59, tzinfo=dt.tzinfo)
 
 
+def _reconcile_events(
+    filtered_icloud_events: list[MergeEvent],
+    source_calendar_events: list[MergeEvent],
+) -> tuple[list[MergeEvent], bool]:
+    """Match source events against iCloud events by (start, end) and assign actions.
+
+    Returns (merge_events, has_additions). Mutates event.action in place on the
+    inputs.
+    """
+    merge_events: list[MergeEvent] = []
+
+    if filtered_icloud_events:
+        source_event_map: dict[tuple[datetime, datetime], list[MergeEvent]] = {}
+        for source_event in source_calendar_events:
+            source_event_map.setdefault((source_event.start, source_event.end), []).append(source_event)
+
+        for icloud_event in filtered_icloud_events:
+            event_time = (icloud_event.start, icloud_event.end)
+            bucket = source_event_map.get(event_time, [])
+            if bucket:
+                matched = bucket.pop(0)
+                matched.action = EventAction.none
+                icloud_event.action = EventAction.none
+            else:
+                icloud_event.action = EventAction.delete
+            merge_events.append(icloud_event)
+
+        events_to_add = [event for event in source_calendar_events if event.action is None]
+        has_additions = len(events_to_add) > 0
+    else:
+        has_additions = len(source_calendar_events) > 0
+        events_to_add = source_calendar_events
+
+    if has_additions:
+        for source_event in events_to_add:
+            source_event.action = EventAction.add
+            merge_events.append(source_event)
+
+    return merge_events, has_additions
+
+
 def _collect_icloud_events(raw_events: list, skip_days: list[str]) -> list[MergeEvent]:
     events: list[MergeEvent] = []
     for raw_event in raw_events:
@@ -579,41 +620,15 @@ def main():
         source_tag = f"[{calendar_tag}] {calendar_title}/{calendar_source}"
         print_step(TAG_CALENDAR_MERGE, f"filtering {source_tag} events in iCloud calendar...", one_liner=False)
         filtered_icloud_events = [event for event in icloud_events if event.title == source_tag]
-        merge_events: list[MergeEvent] = []
-        event_addition = False
         term.print_done()
 
-        print_step(TAG_CALENDAR_MERGE, "identifying events to remove...", one_liner=False)
-        if filtered_icloud_events:
-            source_event_map: dict[tuple[datetime, datetime], list[MergeEvent]] = {}
-            for source_event in source_calendar_events:
-                source_event_map.setdefault((source_event.start, source_event.end), []).append(source_event)
-
-            for icloud_event in filtered_icloud_events:
-                event_time = (icloud_event.start, icloud_event.end)
-                bucket = source_event_map.get(event_time, [])
-                if bucket:
-                    matched = bucket.pop(0)
-                    matched.action = EventAction.none
-                    icloud_event.action = EventAction.none
-                else:
-                    icloud_event.action = EventAction.delete
-                merge_events.append(icloud_event)
-
-            events_to_add = [event for event in source_calendar_events if event.action is None]
-            event_addition = len(events_to_add) > 0
-        else:
-            event_addition = True
-            events_to_add = source_calendar_events
-        term.print_done()
-
+        print_step(TAG_CALENDAR_MERGE, "reconciling events...", one_liner=False)
+        merge_events, event_addition = _reconcile_events(filtered_icloud_events, source_calendar_events)
         if event_addition:
-            print_step(TAG_CALENDAR_MERGE, "identifying events to add...", one_liner=False)
-            for source_event in events_to_add:
-                source_event.title = source_tag
-                source_event.action = EventAction.add
-                merge_events.append(source_event)
-            term.print_done()
+            for event in merge_events:
+                if event.action == EventAction.add:
+                    event.title = source_tag
+        term.print_done()
 
         print_step(TAG_CALENDAR_MERGE, "synchronizing events to iCloud calendar...", one_liner=False)
         actionable_events = [event for event in merge_events if event.action != EventAction.none]

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,303 @@
+"""Unit tests for pure logic functions in merge.py."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from merge import (
+    EventAction,
+    MergeEvent,
+    _calculate_future_date,
+    _end_of_day,
+    _normalize_skip_days,
+    _reconcile_events,
+    build_datetime,
+    get_datetime,
+    get_from_list,
+    get_tag,
+)
+
+# --- EventAction enum ---
+
+
+class TestEventAction:
+    def test_values(self):
+        assert EventAction.none.value == 0
+        assert EventAction.add.value == 1
+        assert EventAction.delete.value == 2
+
+
+# --- MergeEvent dataclass ---
+
+
+class TestMergeEvent:
+    def test_construction(self):
+        dt = datetime(2026, 4, 15, 10, 0)
+        event = MergeEvent(title="test", start=dt, end=dt, full_event=None, action=EventAction.add)
+        assert event.title == "test"
+        assert event.start == dt
+        assert event.action == EventAction.add
+
+    def test_action_mutable(self):
+        dt = datetime(2026, 4, 15, 10, 0)
+        event = MergeEvent(title="test", start=dt, end=dt, full_event=None, action=None)
+        event.action = EventAction.delete
+        assert event.action == EventAction.delete
+
+    def test_none_fields(self):
+        dt = datetime(2026, 4, 15, 10, 0)
+        event = MergeEvent(title=None, start=dt, end=dt, full_event=None, action=None)
+        assert event.title is None
+        assert event.full_event is None
+        assert event.action is None
+
+
+# --- get_datetime ---
+
+
+class TestGetDatetime:
+    def test_strips_seconds_and_microseconds(self):
+        dt = datetime(2026, 4, 15, 14, 30, 45, 123456)
+        result = get_datetime(dt)
+        assert result == datetime(2026, 4, 15, 14, 30)
+
+    def test_preserves_timezone(self):
+        tz = ZoneInfo("America/New_York")
+        dt = datetime(2026, 4, 15, 14, 30, 45, tzinfo=tz)
+        result = get_datetime(dt)
+        assert result.tzinfo == tz
+
+    def test_naive_datetime(self):
+        dt = datetime(2026, 4, 15, 14, 30, 45)
+        result = get_datetime(dt)
+        assert result.tzinfo is None
+
+
+# --- get_from_list ---
+
+
+class TestGetFromList:
+    def test_dict_get(self):
+        assert get_from_list({"a": 1}, "a") == 1
+
+    def test_missing_key(self):
+        assert get_from_list({"a": 1}, "b") is None
+
+    def test_non_dict_input(self):
+        assert get_from_list([1, 2], "x") is None
+
+    def test_none_input(self):
+        assert get_from_list(None, "x") is None
+
+    def test_value_is_none(self):
+        assert get_from_list({"a": None}, "a") is None
+
+
+# --- build_datetime ---
+
+
+class TestBuildDatetime:
+    def test_basic(self):
+        tz = ZoneInfo("UTC")
+        result = build_datetime([0, 2026, 4, 15, 14, 30], tz)
+        assert result == datetime(2026, 4, 15, 14, 30, tzinfo=tz)
+
+    def test_tuple_input(self):
+        tz = ZoneInfo("UTC")
+        result = build_datetime((0, 2026, 4, 15, 14, 30), tz)
+        assert result == datetime(2026, 4, 15, 14, 30, tzinfo=tz)
+
+    def test_non_utc_timezone(self):
+        tz = ZoneInfo("America/New_York")
+        result = build_datetime([0, 2026, 4, 15, 14, 30], tz)
+        assert result.tzinfo == tz
+
+    def test_short_sequence_raises(self):
+        with pytest.raises(IndexError):
+            build_datetime([0, 2026, 3], ZoneInfo("UTC"))
+
+
+# --- get_tag ---
+
+
+class TestGetTag:
+    def test_basic(self):
+        assert get_tag("foo") == "[foo]"
+
+    def test_empty_string(self):
+        assert get_tag("") == "[]"
+
+
+# --- _normalize_skip_days ---
+
+
+class TestNormalizeSkipDays:
+    def test_string_input(self):
+        assert _normalize_skip_days("5, 6") == ["5", "6"]
+
+    def test_string_extra_whitespace(self):
+        assert _normalize_skip_days(" 5 , 6 , ") == ["5", "6"]
+
+    def test_list_of_ints(self):
+        assert _normalize_skip_days([5, 6]) == ["5", "6"]
+
+    def test_list_of_strings(self):
+        assert _normalize_skip_days(["5", "6"]) == ["5", "6"]
+
+    def test_empty_string(self):
+        assert _normalize_skip_days("") == []
+
+    def test_none(self):
+        assert _normalize_skip_days(None) == []
+
+    def test_empty_list(self):
+        assert _normalize_skip_days([]) == []
+
+
+# --- _calculate_future_date ---
+
+
+class TestCalculateFutureDate:
+    def test_no_skip_days(self):
+        # Monday 2026-03-23 + 5 days = Saturday 2026-03-28
+        start = datetime(2026, 3, 23)
+        result = _calculate_future_date(start, 5, [])
+        assert result == datetime(2026, 3, 28)
+
+    def test_skip_weekends_from_monday(self):
+        # Monday 2026-03-23, skip 5/6. Tue(1), Wed(2), Thu(3), Fri(4), Sat skip,
+        # Sun skip, Mon(5) = 2026-03-30.
+        start = datetime(2026, 3, 23)
+        result = _calculate_future_date(start, 5, ["5", "6"])
+        assert result == datetime(2026, 3, 30)
+
+    def test_skip_weekends_spanning_weekend(self):
+        # Thursday 2026-03-26 + 3 non-weekend days with skip 5,6
+        # Fri(1), Sat skip, Sun skip, Mon(2), Tue(3) = 2026-03-31
+        start = datetime(2026, 3, 26)
+        result = _calculate_future_date(start, 3, ["5", "6"])
+        assert result == datetime(2026, 3, 31)
+
+    def test_zero_future_days(self):
+        start = datetime(2026, 3, 23)
+        result = _calculate_future_date(start, 0, ["5", "6"])
+        assert result == start
+
+    def test_future_days_one(self):
+        start = datetime(2026, 3, 23)
+        result = _calculate_future_date(start, 1, [])
+        assert result == datetime(2026, 3, 24)
+
+
+# --- _end_of_day ---
+
+
+class TestEndOfDay:
+    def test_basic(self):
+        tz = ZoneInfo("UTC")
+        dt = datetime(2026, 4, 15, 10, 30, tzinfo=tz)
+        result = _end_of_day(dt)
+        assert result == datetime(2026, 4, 15, 23, 59, 59, tzinfo=tz)
+
+    def test_midnight_input(self):
+        dt = datetime(2026, 4, 15, 0, 0, 0)
+        result = _end_of_day(dt)
+        assert result == datetime(2026, 4, 15, 23, 59, 59)
+
+    def test_preserves_naive(self):
+        dt = datetime(2026, 4, 15, 10, 30)
+        result = _end_of_day(dt)
+        assert result.tzinfo is None
+
+
+# --- _reconcile_events ---
+
+
+def _make_event(start_hour: int, end_hour: int, title: str = "test") -> MergeEvent:
+    """Helper to create MergeEvent instances at a fixed date."""
+    start = datetime(2026, 4, 15, start_hour, 0, tzinfo=ZoneInfo("UTC"))
+    end = datetime(2026, 4, 15, end_hour, 0, tzinfo=ZoneInfo("UTC"))
+    return MergeEvent(title=title, start=start, end=end, full_event=None, action=None)
+
+
+class TestReconcileEvents:
+    def test_no_icloud_all_source_added(self):
+        source = [_make_event(9, 10), _make_event(11, 12)]
+        merge_events, has_additions = _reconcile_events([], source)
+        assert has_additions is True
+        assert len(merge_events) == 2
+        assert all(e.action == EventAction.add for e in merge_events)
+
+    def test_both_empty(self):
+        merge_events, has_additions = _reconcile_events([], [])
+        assert has_additions is False
+        assert len(merge_events) == 0
+
+    def test_matching_events_marked_none(self):
+        icloud = [_make_event(9, 10, title="[WRK] Work/Google")]
+        source = [_make_event(9, 10)]
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        assert has_additions is False
+        assert len(merge_events) == 1
+        assert merge_events[0].action == EventAction.none
+
+    def test_icloud_not_in_source_deleted(self):
+        icloud = [_make_event(9, 10, title="[WRK] Work/Google")]
+        source = []
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        assert has_additions is False
+        assert len(merge_events) == 1
+        assert merge_events[0].action == EventAction.delete
+
+    def test_source_not_in_icloud_added(self):
+        icloud = [_make_event(9, 10, title="[WRK] Work/Google")]
+        source = [_make_event(9, 10), _make_event(14, 15)]
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        assert has_additions is True
+        added = [e for e in merge_events if e.action == EventAction.add]
+        matched = [e for e in merge_events if e.action == EventAction.none]
+        assert len(added) == 1
+        assert added[0].start.hour == 14
+        assert len(matched) == 1
+
+    def test_duplicate_times_in_source(self):
+        icloud = [_make_event(9, 10, title="[WRK] Work/Google")]
+        source = [_make_event(9, 10), _make_event(9, 10)]
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        assert has_additions is True
+        added = [e for e in merge_events if e.action == EventAction.add]
+        matched = [e for e in merge_events if e.action == EventAction.none]
+        assert len(added) == 1
+        assert len(matched) == 1
+
+    def test_duplicate_times_in_icloud(self):
+        icloud = [
+            _make_event(9, 10, title="[WRK] Work/Google"),
+            _make_event(9, 10, title="[WRK] Work/Google"),
+        ]
+        source = [_make_event(9, 10)]
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        assert has_additions is False
+        deleted = [e for e in merge_events if e.action == EventAction.delete]
+        matched = [e for e in merge_events if e.action == EventAction.none]
+        assert len(deleted) == 1
+        assert len(matched) == 1
+
+    def test_mixed_add_delete_none(self):
+        icloud = [
+            _make_event(9, 10, title="[WRK] Work/Google"),  # matches source
+            _make_event(11, 12, title="[WRK] Work/Google"),  # no source match → delete
+        ]
+        source = [
+            _make_event(9, 10),  # matches icloud
+            _make_event(14, 15),  # no icloud match → add
+        ]
+        merge_events, has_additions = _reconcile_events(icloud, source)
+        assert has_additions is True
+        actions = {action: [] for action in EventAction}
+        for e in merge_events:
+            actions[e.action].append(e)
+        assert len(actions[EventAction.none]) == 1
+        assert len(actions[EventAction.delete]) == 1
+        assert len(actions[EventAction.add]) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -53,6 +53,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -63,6 +64,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pyfangs", git = "ssh://git@github.com/leandrorojas/pyfangs?rev=v0.7.3" },
     { name = "pyicloud", specifier = "==2.5.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
 ]
 provides-extras = ["dev"]
@@ -386,6 +388,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -497,12 +508,30 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -673,6 +702,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/74/ad81d5c68940964550ad281a616b310249721b4fb0eaf84fa91b4d881921/pyicloud-2.5.0.tar.gz", hash = "sha256:b31127a50c015a71ebaa4188b08ed7f4c3ad0e02131a8ce3d81081ece9154be7", size = 407318, upload-time = "2026-04-03T18:56:50.901Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/0c/028cce89ad1e59a60d4471c900bddce5d0c1c2392816b67ceed05d0ac4ae/pyicloud-2.5.0-py3-none-any.whl", hash = "sha256:00ebfe8feda19b3dd535fba53155dd6c872d44cd7baac23ade15782fd320d42d", size = 234838, upload-time = "2026-04-03T18:56:49.199Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Meta-PR 2 of the tooling improvements plan. Adds pytest, extracts the event reconciliation logic from `main()`, and covers all pure logic with 41 unit tests.

**Base branch:** `tooling/ruff-precommit-dependabot` (PR #48). Merge #48 first.

- Add `pytest` to `[project.optional-dependencies].dev` with pytest config
- Extract `_reconcile_events()` from `main()` for testability
- 41 unit tests covering:
  - `EventAction` enum + `MergeEvent` dataclass
  - `get_datetime`, `get_from_list`, `build_datetime`, `get_tag`
  - `_normalize_skip_days`, `_calculate_future_date`, `_end_of_day`
  - `_reconcile_events` (add/delete/none cases, duplicates, mixed scenarios)
- Bonus bug fix: `callable | None` was using the builtin function as a type; replaced with `Callable[[], None]` from `collections.abc`

## Test plan
- [x] `uv run pytest tests/ -v` → 41 passed
- [x] `uv run pre-commit run --all-files` → all hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pytest testing framework as a development dependency with automated test discovery configuration.

* **Refactor**
  * Reorganized event reconciliation logic for improved code maintainability.

* **Tests**
  * Added comprehensive test suite covering event handling, datetime operations, date calculations, and synchronization logic across multiple scenarios with extensive edge case validation including duplicate detection and timezone handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->