### PR TITLE
docs: CHANGELOG, PR/issue templates, SECURITY

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Something isn't working as expected
+labels: bug
+---
+
+## What happened
+<!-- Clear description of the bug -->
+
+## Expected behavior
+<!-- What did you expect? -->
+
+## Steps to reproduce
+1.
+2.
+3.
+
+## Environment
+- OS:
+- Python version:
+- calendar-merge version/tag:
+- pyicloud version:
+
+## Logs / error output
+<!-- Paste relevant terminal output, sanitize any secrets -->
+
+```
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest an enhancement
+labels: enhancement
+---
+
+## Problem
+<!-- What are you trying to accomplish? -->
+
+## Proposed solution
+<!-- How would this feature work? -->
+
+## Alternatives considered
+<!-- Other approaches you thought about -->
+
+## Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Summary
+<!-- What does this change do and why? 1-3 bullets. -->
+
+## Test plan
+<!-- How was this verified? -->
+- [ ] `uv run pytest tests/` passes
+- [ ] `uv run pre-commit run --all-files` passes
+- [ ] Manual run on server (if runtime-affecting)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented here. Format loosely
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions are
+tagged in git.
+
+## [Unreleased]
+
+### Added
+- Ruff linter and formatter with pre-commit hooks
+- Pytest unit tests covering pure logic (41 tests)
+- Mypy type checking with lenient baseline
+- GitHub Actions CI (lint + test + typecheck)
+- Dependabot for weekly dependency and GitHub Actions updates
+- `.editorconfig` for cross-editor consistency
+- Telegram reply poll timeout (default 5 min) to prevent indefinite hang
+
+### Changed
+- Extracted `_reconcile_events()` from `main()` for testability
+
+## [v0.1.4] — 2026-04-14
+
+### Fixed
+- iCloud 2FA trusted-device push stopped working after Apple's server-side
+  changes in late March 2026.
+
+### Changed
+- Upgraded pyicloud 2.1.0 → 2.5.0 (HSA2 bridge flow via PR #210).
+- Removed `google-generativeai` and the Gemini AI-generated Telegram
+  messages. `--first`/`--last` now send plain Telegram notifications.
+- Upgraded pyfangs v0.7.2 → v0.7.3 (AI/DB dependencies became optional extras).
+- Disabled pyicloud's SMS fallback in `validate_2fa()` — the bridge would time
+  out on its WebSocket return payload (while still pushing the code to the
+  device), causing the delivery method to silently switch to SMS and reject
+  the trusted-device code at validation.
+
+## [v0.1.3] and earlier
+
+See git history for details. Tags v0.2.0 – v0.2.2 were marked as pre-release
+on GitHub because that work (override/cancel, dry-run, state management) was
+reverted in PR #42.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+This project handles iCloud credentials and Telegram bot tokens. If you discover
+a security issue, please report it privately instead of opening a public issue.
+
+## Reporting
+
+Use GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+feature on this repository, or email the maintainer directly.
+
+Include:
+- Description of the issue and its impact
+- Steps to reproduce
+- Affected version(s) or commits
+
+## Scope
+
+The following are in scope:
+- Credential leakage (iCloud, Telegram, Gemini)
+- Insecure handling of ICS feed contents
+- Dependency vulnerabilities with a practical impact here
+
+Out of scope:
+- Issues in upstream libraries (`pyicloud`, `pyfangs`, `icalendar`) — please
+  report those to their maintainers.
+
+## Response
+
+Maintainer response is best-effort since this is a hobby project. Critical
+issues (credential exposure, RCE) will be prioritized.


### PR DESCRIPTION
## Summary
Meta-PR 6 (final). Adds repo polish files — pure markdown/meta, no code changes.

**Base branch:** `runtime/logging-and-timeout` (PR #52). Merge all earlier PRs first.

- **CHANGELOG.md** — Keep-a-Changelog format documenting v0.1.4 and the upcoming tooling changes
- **.github/PULL_REQUEST_TEMPLATE.md** — enforces Summary + Test plan on new PRs
- **.github/ISSUE_TEMPLATE/bug_report.md** and **feature_request.md**
- **SECURITY.md** — points to GitHub's private vulnerability reporting (relevant since this handles iCloud/Telegram credentials)

## Test plan
- [x] `uv run pre-commit run --all-files` → all hooks pass
- [x] Manually reviewed each file for accuracy